### PR TITLE
Remove Deprecated no-unused-variable Rule

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -9,7 +9,6 @@ module.exports = {
     /* tslint */
     "await-promise": [true, "Bluebird"],
     "no-floating-promises": [true, "Bluebird"],
-    "no-unused-variable": [true, "check-parameters", { "ignore-pattern": "^_" }],
     "no-use-before-declare": true,
     "no-duplicate-super": true,
     "no-inferred-empty-object-type": true,


### PR DESCRIPTION
TSLint has deprecated `no-unused-variable` and now recommends using the built in compiler checks in TypeScript >= 2.9 to achieve the same result.