### PR TITLE
Fix usage of path.join, removing literal separator

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -4,7 +4,7 @@ const sonarTsRoot = dirname(require.resolve("tslint-sonarts"));
 const microsoftContribRoot = dirname(require.resolve("tslint-microsoft-contrib"));
 
 module.exports = {
-  rulesDirectory: [join(sonarTsRoot, "lib/rules"), microsoftContribRoot],
+  rulesDirectory: [join(sonarTsRoot, "lib", "rules"), microsoftContribRoot],
   rules: {
     /* tslint */
     "await-promise": [true, "Bluebird"],


### PR DESCRIPTION
While [`path.join`][1] can merge paths segments with separators included, its purpose is to be agnostic of the separator and thus passing in literal segments with separators included defeats that purpose. This PR removes the path separator from the literal segment.

  [1]:https://nodejs.org/api/path.html#path_path_join_paths