### PR TITLE
Fix TSLint casing in prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <img src="https://emojipedia-us.s3.amazonaws.com/thumbs/240/apple/129/bug_1f41b.png" width="120" alt="TypeStrict">
   <h3 align="center">TypeStrict</h3> 
-  <p align="center">Squash bugs before shipping them with Typescript and TSlint!</p>
-  <p align="center">Tslint config focused on maximizing type safety</p>
+  <p align="center">Squash bugs before shipping them with Typescript and TSLint!</p>
+  <p align="center">TSLint config focused on maximizing type safety</p>
   <p align="center">
     <img alt="Downloads" src="https://img.shields.io/npm/dm/typestrict.svg">
     <a href="/package.json"><img alt="Software License" src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square"></a>
@@ -50,7 +50,7 @@ care about code style or formatting.
 
 ## Complete rules list
 
-### Tslint
+### TSLint
 
 - [await-promise](https://palantir.github.io/tslint/rules/await-promise/)
 - [no-floating-promises](https://palantir.github.io/tslint/rules/no-floating-promises/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typestrict",
-  "description": "Tslint config focused on maximizing type safety",
+  "description": "TSLint config focused on maximizing type safety",
   "keywords": [
     "typescript",
     "tslint",


### PR DESCRIPTION
This PR fixes the casing of the name TSLint in the package contents. I might also suggest updating the GitHub repository description. 😄 