### PR TITLE
feat: add additonnal rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ care about code style or formatting.
 - [no-misused-new](https://palantir.github.io/tslint/rules/no-misused-new/)
 - [restrict-plus-operands](https://palantir.github.io/tslint/rules/restrict-plus-operands/)
 - [use-isnan](https://palantir.github.io/tslint/rules/use-isnan/)
+- [no-async-without-await](https://palantir.github.io/tslint/rules/no-async-without-await/)
+- [no-promise-as-boolean](https://palantir.github.io/tslint/rules/no-promise-as-boolean/)
+- [no-for-in](https://palantir.github.io/tslint/rules/no-for-in/)
+- [invalid-void](https://palantir.github.io/tslint/rules/invalid-void/)
+- [strict-comparisons](https://palantir.github.io/tslint/rules/strict-comparisons/)
 
 ### SonarTS
 

--- a/README.md
+++ b/README.md
@@ -53,20 +53,20 @@ care about code style or formatting.
 ### TSLint
 
 - [await-promise](https://palantir.github.io/tslint/rules/await-promise/)
-- [no-floating-promises](https://palantir.github.io/tslint/rules/no-floating-promises/)
-- [no-unused-variable](https://palantir.github.io/tslint/rules/no-unused-variable/) (with `"check-parameters"` and `{"ignore-pattern": "^_" }`)
-- [no-use-before-declare](https://palantir.github.io/tslint/rules/no-use-before-declare/)
+- [invalid-void](https://palantir.github.io/tslint/rules/invalid-void/)
+- [no-async-without-await](https://palantir.github.io/tslint/rules/no-async-without-await/)
 - [no-duplicate-super](https://palantir.github.io/tslint/rules/no-duplicate-super/)
+- [no-floating-promises](https://palantir.github.io/tslint/rules/no-floating-promises/)
+- [no-for-in](https://palantir.github.io/tslint/rules/no-for-in/)
 - [no-inferred-empty-object-type](https://palantir.github.io/tslint/rules/no-inferred-empty-object-type/)
 - [no-invalid-this](https://palantir.github.io/tslint/rules/no-invalid-this/)
 - [no-misused-new](https://palantir.github.io/tslint/rules/no-misused-new/)
-- [restrict-plus-operands](https://palantir.github.io/tslint/rules/restrict-plus-operands/)
-- [use-isnan](https://palantir.github.io/tslint/rules/use-isnan/)
-- [no-async-without-await](https://palantir.github.io/tslint/rules/no-async-without-await/)
 - [no-promise-as-boolean](https://palantir.github.io/tslint/rules/no-promise-as-boolean/)
-- [no-for-in](https://palantir.github.io/tslint/rules/no-for-in/)
-- [invalid-void](https://palantir.github.io/tslint/rules/invalid-void/)
+- [no-unused-variable](https://palantir.github.io/tslint/rules/no-unused-variable/) (with `"check-parameters"` and `{"ignore-pattern": "^_" }`)
+- [no-use-before-declare](https://palantir.github.io/tslint/rules/no-use-before-declare/)
+- [restrict-plus-operands](https://palantir.github.io/tslint/rules/restrict-plus-operands/)
 - [strict-comparisons](https://palantir.github.io/tslint/rules/strict-comparisons/)
+- [use-isnan](https://palantir.github.io/tslint/rules/use-isnan/)
 
 ### SonarTS
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ care about code style or formatting.
 ### TSLint
 
 - [await-promise](https://palantir.github.io/tslint/rules/await-promise/)
-- [invalid-void](https://palantir.github.io/tslint/rules/invalid-void/)
-- [no-async-without-await](https://palantir.github.io/tslint/rules/no-async-without-await/)
 - [no-duplicate-super](https://palantir.github.io/tslint/rules/no-duplicate-super/)
 - [no-floating-promises](https://palantir.github.io/tslint/rules/no-floating-promises/)
 - [no-for-in](https://palantir.github.io/tslint/rules/no-for-in/)

--- a/tslint.js
+++ b/tslint.js
@@ -8,20 +8,20 @@ module.exports = {
   rules: {
     /* tslint */
     "await-promise": [true, "Bluebird"],
-    "no-floating-promises": [true, "Bluebird"],
-    "no-unused-variable": [true, "check-parameters", { "ignore-pattern": "^_" }],
-    "no-use-before-declare": true,
+    "invalid-void": true,
+    "no-async-without-await": true,
     "no-duplicate-super": true,
+    "no-floating-promises": [true, "Bluebird"],
+    "no-for-in": true,
     "no-inferred-empty-object-type": true,
     "no-invalid-this": true,
     "no-misused-new": true,
-    "restrict-plus-operands": true,
-    "use-isnan": true,
-    "no-async-without-await": true,
     "no-promise-as-boolean": true,
-    "no-for-in": true,
-    "invalid-void": true,
+    "no-unused-variable": [true, "check-parameters", { "ignore-pattern": "^_" }],
+    "no-use-before-declare": true,
+    "restrict-plus-operands": true,
     "strict-comparisons": true,
+    "use-isnan": true,
 
     /* sonarts */
     "no-accessor-field-mismatch": true,

--- a/tslint.js
+++ b/tslint.js
@@ -17,6 +17,11 @@ module.exports = {
     "no-misused-new": true,
     "restrict-plus-operands": true,
     "use-isnan": true,
+    "no-async-without-await": true,
+    "no-promise-as-boolean": true,
+    "no-for-in": true,
+    "invalid-void": true,
+    "strict-comparisons": true,
 
     /* sonarts */
     "no-accessor-field-mismatch": true,

--- a/tslint.js
+++ b/tslint.js
@@ -8,8 +8,6 @@ module.exports = {
   rules: {
     /* tslint */
     "await-promise": [true, "Bluebird"],
-    "invalid-void": true,
-    "no-async-without-await": true,
     "no-duplicate-super": true,
     "no-floating-promises": [true, "Bluebird"],
     "no-for-in": true,


### PR DESCRIPTION
Added some more rules from tslint:

- [no-async-without-await](https://palantir.github.io/tslint/rules/no-async-without-await/)
- [no-promise-as-boolean](https://palantir.github.io/tslint/rules/no-promise-as-boolean/)
- [no-for-in](https://palantir.github.io/tslint/rules/no-for-in/)
- [invalid-void](https://palantir.github.io/tslint/rules/invalid-void/)
- [strict-comparisons](https://palantir.github.io/tslint/rules/strict-comparisons/)

I, basically, read the changelog and added the rules that add some strictness without being a pain in the ass.

Also, the rules has been reordered alphabetically (this commit can be removed if needed).

Closes #14 